### PR TITLE
Enable Debug/Release build modes + run sanitizers on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: generic
+
+sudo: false
+
+addons_shortcuts:
+  addons_clang35: &clang35
+    apt:
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
+      packages: [ 'clang-3.5', 'llvm-3.5-dev' ]
+  addons_gcc49: &gcc5
+    apt:
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'g++-5' ]
+
+matrix:
+  include:
+    - os: linux
+      compiler: "clang35"
+      env: CXX=clang++-3.5 BUILDTYPE=Release
+      addons: *clang35
+    - os: linux
+      compiler: "clang35"
+      env: CXX=clang++-3.5 BUILDTYPE=Debug CXXFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
+      addons: *clang35
+    - os: linux
+      compiler: "clang35"
+      env: CXX=clang++-3.5 BUILDTYPE=Debug CXXFLAGS="-fsanitize=integer" LDFLAGS="-fsanitize=integer"
+      addons: *clang35
+    - os: linux
+      compiler: "gcc5"
+      env: CXX=g++-5 BUILDTYPE=Release
+      addons: *gcc5
+
+install:
+ - BUILDTYPE=${BUILDTYPE} make
+
+#script:
+ # take too long, needs smaller data for travis
+ #- BUILDTYPE=${BUILDTYPE} make test

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,28 @@
-CXX := $(CXX)
-CXXFLAGS := -fvisibility=hidden -Wall -Wextra -Wfloat-equal -Wundef -Wcast-align -Wwrite-strings -Wlong-long -Wmissing-declarations -Wredundant-decls -Wshadow -Woverloaded-virtual
-LDFLAGS := -lz -lpthread -lboost_program_options -lboost_filesystem -lboost_system
+BUILDTYPE ?= Release
 
-osm-tiler: clean
-	. ./bootstrap.sh && $(CXX) osm-tiler.cpp -o osm-tiler -std=c++11 $(CXXFLAGS) $(LDFLAGS);
+CXX := $(CXX)
+CXXFLAGS := $(CXXFLAGS) -std=c++11 -fvisibility=hidden
+LDFLAGS := $(LDFLAGS) -lz -lpthread -lboost_program_options -lboost_filesystem -lboost_system
+WARNING_FLAGS := -Wall -Wextra -Wfloat-equal -Wundef -Wcast-align -Wwrite-strings -Wlong-long -Wmissing-declarations -Wredundant-decls -Wshadow -Woverloaded-virtual
+
+MASON_HOME := ./mason_packages/.link
+
+RELEASE_FLAGS := -O3 -DNDEBUG
+DEBUG_FLAGS := -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
+
+ifeq ($(BUILDTYPE),Release)
+	FINAL_FLAGS := -g $(WARNING_FLAGS) $(RELEASE_FLAGS)
+else
+	FINAL_FLAGS := -g $(WARNING_FLAGS) $(DEBUG_FLAGS)
+endif
+
+all: osm-tiler
+
+mason_packages:
+	./bootstrap.sh
+
+osm-tiler: clean mason_packages
+	$(CXX) osm-tiler.cpp -o osm-tiler -I$(MASON_HOME)/include -L$(MASON_HOME)/lib $(CXXFLAGS) $(FINAL_FLAGS) $(LDFLAGS);
 
 chs.osm.pbf:
 	curl https://s3.amazonaws.com/metro-extracts.mapzen.com/charleston_south-carolina.osm.pbf -o chs.osm.pbf

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,12 +28,7 @@ function setup_mason() {
     (cd ./.mason && git fetch > /dev/null 2>&1 && git checkout ${MASON_VERSION} > /dev/null 2>&1)
   fi
 
-  wd=$(pwd)
-  export MASON_DIR=${wd}/.mason
-  export MASON_HOME=${wd}/mason_packages/.link
-  export PATH=${wd}/.mason:$PATH
-  export CXX=${CXX:-clang++}
-  export CC=${CC:-clang}
+  export MASON_DIR=$(pwd)/.mason
 }
 
 function main() {
@@ -42,12 +37,6 @@ function main() {
   if [[ ! -d ${MASON_HOME} ]]; then
     all_deps
   fi
-
-  export C_INCLUDE_PATH="${MASON_HOME}/include"
-  export CPLUS_INCLUDE_PATH="${MASON_HOME}/include"
-  export CXXFLAGS="-I${MASON_HOME}/include"
-  export LIBRARY_PATH="${MASON_HOME}/lib"
-  export LDFLAGS="-L${MASON_HOME}/lib"
 }
 
 main


### PR DESCRIPTION
I saw this repo, did not see a branch indicated any work on travis testing yet, so figured I'd help get testing in place.

I've enabled travis. In addition to adding a travis.yml this change:

  - Makes the default build include `-O3 -DNDEBUG` for top performance
  - Makes it possible to build in debug mode like `BUILDTYPE=Debug make`
  - Adds `-g` to both Debug and Release modes so that backtraces from crashes will be decent
  - Modifies bootstrap.sh to avoid needed to export ENV variables. This dodges a silly issue on travis whereby `. bootstrap.sh` fails because when done in the Makefile the shell is `sh` instead of `bash.
  - Starts running the Address Sanitizer and Integer Sanitizers on travis:
   - If a memory leak or invalid access is detected the Address Sanitizer will throw and the travis job will fail
   - If an integer overflow is detected a non-fatal warning will be printed - so looking at the travis logs for this job is key. Throwing would be possible but not always a good idea since sometimes the errors are spurious or come from other upstream libraries
   - Both of these work at runtime, so they will not do anything new until tests are added to travis that actually run the program
 - Currently the tests are not enabled in the travis.yml because I saw they took a while to run (> 5 min). @morganherlocker - want to hook up some smaller test data to run on travis?