### PR TITLE
implement explicit input flag and positional options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ mason_packages:
 	./bootstrap.sh
 
 osm-tiler: mason_packages handler.hpp osm-tiler.cpp
-	$(CXX) osm-tiler.cpp -o osm-tiler -I$(MASON_HOME)/include -L$(MASON_HOME)/lib $(CXXFLAGS) $(FINAL_FLAGS) $(LDFLAGS);
+	$(CXX) osm-tiler.cpp -o osm-tiler -isystem$(MASON_HOME)/include -L$(MASON_HOME)/lib $(CXXFLAGS) $(FINAL_FLAGS) $(LDFLAGS);
 
 chs.osm.pbf:
 	curl https://s3.amazonaws.com/metro-extracts.mapzen.com/charleston_south-carolina.osm.pbf -o chs.osm.pbf
 
 test: chs.osm.pbf osm-tiler
-	./osm-tiler chs.osm.pbf -z 9 -o ./output;
+	./osm-tiler -z 9 -o ./output chs.osm.pbf;
 
 clean:
 	rm -f osm-tiler; rm -rf output; mkdir output;

--- a/osm-tiler.cpp
+++ b/osm-tiler.cpp
@@ -23,10 +23,15 @@ int main(int argc, char** argv) {
     ("help,h", "show help")
     ("version,v", "show version number")
     ("zoom,z", value<uint>(), "zoom level of tiles")
-    ("output,o", value<string>(), "output directory");;
+    ("input,i", value<string>(), "input OpenStreetMap file")
+    ("output,o", value<string>(), "output directory");
 
+    positional_options_description p;
+    p.add("input", 1);
     variables_map vm;
-    store(parse_command_line(argc, argv, desc), vm);
+
+    auto parser = command_line_parser(argc, argv).options(desc).positional(p);
+    store(parser.run(), vm);
 
     if(vm.count("help")) {
       cout << desc;
@@ -35,22 +40,28 @@ int main(int argc, char** argv) {
     } else {
       uint zoom = 0;
       string output;
+      string input;
 
       if(vm.count("zoom")) zoom = vm["zoom"].as<uint>();
       else {
         cout << "Error: A zoom level is required" << endl;
         return 1;
       }
+
       if(vm.count("output")) output = vm["output"].as<string>();
       else {
         cout << "Error: An output directory is required" << endl;
         return 1;
       }
 
-      std::string filename = argv[1];
+      if(vm.count("input")) input = vm["input"].as<string>();
+      else {
+        cout << "Error: An OpenStreetMap input file is required" << endl;
+        return 1;
+      }
 
       osmium::io::Reader reader(
-        filename,
+        input,
         osmium::osm_entity_bits::relation | osmium::osm_entity_bits::node | osmium::osm_entity_bits::way
       );
 


### PR DESCRIPTION
The current implementation finds the input file by simply parsing argc[1]. This [breaks](https://github.com/mapbox/osm-tiler/issues/23) when the input is in a different position.

This PR addresses the issue by adding an `--input`/`-i` flag, and adding a positional_option that will check for unflagged parameters and assign them to `--input`, or throw an error if there are multiple positionals.

cc @rclark 